### PR TITLE
fix: Use urllib to parse special characters URL-conform.

### DIFF
--- a/metalhistory/data_query_functions.py
+++ b/metalhistory/data_query_functions.py
@@ -3,6 +3,7 @@ from dotenv import load_dotenv
 import numpy as np
 import os
 import sys
+import urllib.parse
 
 class LastFM():
     def __init__(self):
@@ -101,7 +102,7 @@ class LastFM():
         string
             Cleaned string.
         """
-        return str(string).strip().replace('&','%26')
+        return urllib.parse.quote(str(string).strip())
         
 
     def get_album_matches(self, verbose=0, **kwargs):


### PR DESCRIPTION
There was an issue that some special characters in the album search could cause an issue in the API call.

After this fix we are now parsing the input in the clean_string() function to be conform to URLs using urllib.