### PR TITLE
fix: Added missing field to list of accepted fields in config.yaml

### DIFF
--- a/metalhistory/config.yaml
+++ b/metalhistory/config.yaml
@@ -2,6 +2,7 @@ system settings:
   lastfm:
     accepted fields:
       - artist
+      - name 
       - mbid
       - url
       - listeners


### PR DESCRIPTION
Listing the 'name' as accepted field in the config. Corresponds to album name.

Tiny pull request.