### PR TITLE
fix: Updated pytest dependency to higher version.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - xmltodict==0.12.0
   - pandas==1.1.5
   - wordcloud==1.8.1
-  - pytest==3.3.2
+  - pytest==6.2.2
   - squarify==0.4.3
   - networkx==2.5
   - numpy==1.19.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ matplotlib==3.3.4
 networkx==2.5
 wordcloud==1.8.1
 pandas==1.1.5
-pytest==3.3.2
+pytest==6.2.2
 numpy==1.19.2
 xmltodict==0.12.0
 Pillow==8.1.2


### PR DESCRIPTION
Fixing an error with pytest that wouldn't run our test due to an old version listed as dependency.